### PR TITLE
Quick optimization of seeds

### DIFF
--- a/slosepa.py
+++ b/slosepa.py
@@ -45,6 +45,7 @@ rounds = 500000
 conversionDict1 = {}
 conversionDict2 = {}
 conversionDict3 = {}
+dictList = []
 allChar = ascii_letters + digits + punctuation
 allChar1 = list(allChar)
 for i in range(len(allChar1)):
@@ -65,7 +66,9 @@ for i in range(len(allChar3)):
 # idea here, create a list of the initialized dicts
 # then we can reference the index later, instead
 # of an if loop matching a number.
-dictList = [conversionDict1, conversionDict2, conversionDict3]
+dictList.append(conversionDict1)
+dictList.append(conversionDict2)
+dictList.append(conversionDict3)
 
 
 def generate_seed():

--- a/slosepa.py
+++ b/slosepa.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # slosepa.py
 # SLOw hash SEcure Password Author
@@ -30,10 +30,12 @@
 #   2 - gui
 #   3 - browser plugin?
 
+import itertools
 from string import ascii_letters, digits, punctuation
 from secrets import choice as ch
 from secrets import randbelow as randb
 from hashlib import blake2b, sha3_512, sha512
+
 
 # future args
 pwLength = 30
@@ -60,40 +62,28 @@ for i in range(len(allChar3)):
     allChar3.remove(temp)
     conversionDict3[hex(i)] = temp
 
+# idea here, create a list of the initialized dicts
+# then we can reference the index later, instead
+# of an if loop matching a number.
+dictList = [conversionDict1, conversionDict2, conversionDict3]
+
+
+def generate_seed():
+    seed = ''
+    for _ in itertools.repeat(None, pwLength * randb(1337) + 1):
+        j = randb(3)
+        seed += ch(list(dictList[j].values()))
+    return seed
+
+
 # generate seeds to hashing functions
-seed1 = ''
-for i in range(pwLength * randb(1337) + 1):
-    j = randb(3)
-    if j == 0:
-        seed1 += ch(list(conversionDict1.values()))
-    elif j == 1:
-        seed1 += ch(list(conversionDict2.values()))
-    elif j == 2:
-        seed1 += ch(list(conversionDict3.values()))
-# uncomment to print
-#print("'seed1' = " + seed1)
-seed2 = ''
-for i in range(pwLength * randb(1337) + 1):
-    j = randb(3)
-    if j == 0:
-        seed2 += ch(list(conversionDict1.values()))
-    elif j == 1:
-        seed2 += ch(list(conversionDict2.values()))
-    elif j == 2:
-        seed2 += ch(list(conversionDict3.values()))
-# uncomment to print
-#print("\n'seed2' = " + seed2)
-seed3 = ''
-for i in range(pwLength * randb(1337) + 1):
-    j = randb(3)
-    if j == 0:
-        seed3 += ch(list(conversionDict1.values()))
-    elif j == 1:
-        seed3 += ch(list(conversionDict2.values()))
-    elif j == 2:
-        seed3 += ch(list(conversionDict3.values()))
-# uncomment to print
-#print("\n'seed3' = " + seed3)
+funcSeed1 = generate_seed()
+funcSeed2 = generate_seed()
+funcSeed3 = generate_seed()
+# print('function seed1 = {0}'.format(funcSeed1))
+# print('function seed2 = {0}'.format(funcSeed2))
+# print('function seed3 = {0}'.format(funcSeed3))
+
 
 blaked = blake2b()
 sha3d = sha3_512()

--- a/slosepa.py
+++ b/slosepa.py
@@ -36,7 +36,6 @@ from secrets import choice as ch
 from secrets import randbelow as randb
 from hashlib import blake2b, sha3_512, sha512
 
-
 # future args
 pwLength = 30
 rounds = 500000

--- a/slosepa.py
+++ b/slosepa.py
@@ -73,7 +73,7 @@ dictList.append(conversionDict3)
 def generate_seed():
     seed = ''
     for _ in itertools.repeat(None, pwLength * randb(1337) + 1):
-        j = randb(3)
+        j = randb(len(dictList))
         seed += ch(list(dictList[j].values()))
     return seed
 
@@ -91,9 +91,9 @@ blaked = blake2b()
 sha3d = sha3_512()
 sha2d = sha512()
 
-blaked.update(bytearray(seed1, 'utf-8'))
-sha3d.update(bytearray(seed2, 'utf-8'))
-sha2d.update(bytearray(seed3, 'utf-8'))
+blaked.update(bytearray(funcSeed1, 'utf-8'))
+sha3d.update(bytearray(funcSeed2, 'utf-8'))
+sha2d.update(bytearray(funcSeed3, 'utf-8'))
 
 for i in range(rounds):
     blaked.update(bytearray(blaked.hexdigest(), 'utf-8'))


### PR DESCRIPTION
The intent of this PR is to clean up seed generation. To accomplish this we will:

- Define a function to generate seeds. 
- Call that function 3 times, once for each seed. 

Additional items:

- Import and use [itertools](https://docs.python.org/3.8/library/itertools.html#itertools.repeat) instead of range. More efficient and likely fastest way to iterate. 
- Change the script shebang to `/usr/bin/env python3` which is more portable, for example my system reports python3 located at:

```
$ which python3
/usr/local/bin/python3
```

- Combine all the `conversionDict*` into a single list. This allows the function to directly address the index of that list, instead of performing a comparison on `j` in the loop. This also allows much higher scaling, should the number of dictionaries increase. 



